### PR TITLE
Fix Bug: Editted Friend reflected in Plans

### DIFF
--- a/docs/tutorials/AddRemark.md
+++ b/docs/tutorials/AddRemark.md
@@ -293,7 +293,7 @@ While the changes to code may be minimal, the test data will have to be updated 
 
 <div markdown="span" class="alert alert-warning">
 
-:exclamation: You must delete AddressBook’s storage file located at `/data/addressbook.json` before running it! Not doing so will cause AddressBook to default to an empty address book!
+:exclamation: You must delete AddressBook’s storage file located at `/data/friendbook.json` before running it! Not doing so will cause AddressBook to default to an empty address book!
 
 </div>
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -85,6 +85,10 @@ public class EditCommand extends Command {
 
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+
+        // Update details of plans which involves this person
+        model.updatePlansWithPerson(personToEdit, editedPerson);
+
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
     }
 

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.List;
 
@@ -125,6 +126,18 @@ public class AddressBook implements ReadOnlyAddressBook {
         requireNonNull(editedPlan);
 
         plans.setPlan(target, editedPlan);
+    }
+
+    /**
+     * Replaces the given person (@code target} with {@code editedPerson} in plans which involved {@code target}.
+     * {@code target} must exist in the address book.
+     * The person identity of {@code editedPerson} must not be the same as another existing person in the address book.
+     */
+    public void updatePlansWithPerson(ObservableList<Plan> plans, Person editedPerson) {
+        requireAllNonNull(plans, editedPerson);
+        for (Plan plan: plans) {
+            plan.setFriend(editedPerson);
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -121,6 +121,13 @@ public interface Model {
      */
     void setPlan(Plan target, Plan editedPlan);
 
+    /**
+     * Replaces the given person (@code target} with {@code editedPerson} in plans which involved {@code target}.
+     * {@code target} must exist in the address book.
+     * The person identity of {@code editedPerson} must not be the same as another existing person in the address book.
+     */
+    void updatePlansWithPerson(Person target, Person editedPerson);
+
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();
     ObservableList<Plan> getFilteredPlanList();

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -14,6 +14,7 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.plan.Plan;
+import seedu.address.model.plan.PlanContainsFriendPredicate;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -117,8 +118,17 @@ public class ModelManager implements Model {
     @Override
     public void setPerson(Person target, Person editedPerson) {
         requireAllNonNull(target, editedPerson);
-
         addressBook.setPerson(target, editedPerson);
+    }
+
+    @Override
+    public void updatePlansWithPerson(Person target, Person editedPerson) {
+        requireAllNonNull(target, editedPerson);
+        PlanContainsFriendPredicate planContainsFriendPredicate = new PlanContainsFriendPredicate(target);
+        updateFilteredPlanList(planContainsFriendPredicate);
+        ObservableList<Plan> plansWithPerson = getFilteredPlanList();
+        addressBook.updatePlansWithPerson(plansWithPerson, editedPerson);
+        updateFilteredPlanList(PREDICATE_SHOW_ALL_PLANS);
     }
 
     /**
@@ -143,7 +153,6 @@ public class ModelManager implements Model {
     @Override
     public void setPlan(Plan target, Plan editedPlan) {
         requireAllNonNull(target, editedPlan);
-
         addressBook.setPlan(target, editedPlan);
     }
 

--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -14,7 +14,7 @@ import seedu.address.commons.core.GuiSettings;
 public class UserPrefs implements ReadOnlyUserPrefs {
 
     private GuiSettings guiSettings = new GuiSettings();
-    private Path addressBookFilePath = Paths.get("data" , "addressbook.json");
+    private Path addressBookFilePath = Paths.get("data" , "friendbook.json");
     private Path planBookFilePath = Paths.get("data" , "planbook.json");
 
     /**

--- a/src/main/java/seedu/address/model/plan/Plan.java
+++ b/src/main/java/seedu/address/model/plan/Plan.java
@@ -14,7 +14,7 @@ public class Plan {
     /** The date and time of this plan. */
     private final PlanDateTime dateTime;
     /** The friend this plan involves. */
-    private final Person friend;
+    private Person friend;
     private Boolean isComplete = false;
 
     /**
@@ -58,6 +58,10 @@ public class Plan {
     }
     public Boolean getPlanComplete() {
         return isComplete;
+    }
+
+    public void setFriend(Person friend) {
+        this.friend = friend;
     }
 
     /**

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -15,8 +15,8 @@ import seedu.address.commons.core.LogsCenter;
  */
 public class HelpWindow extends UiPart<Stage> {
 
-    public static final String USERGUIDE_URL = "https://se-education.org/addressbook-level3/UserGuide.html";
-    public static final String HELP_MESSAGE = "Refer to the user guide: " + USERGUIDE_URL;
+    public static final String USERGUIDE_URL = "https://ay2324s1-cs2103t-w16-4.github.io/tp/UserGuide.html";
+    public static final String HELP_MESSAGE = "Refer to FriendBook's user guide: " + USERGUIDE_URL;
 
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);
     private static final String FXML = "HelpWindow.fxml";

--- a/src/test/data/JsonUserPrefsStorageTest/ExtraValuesUserPref.json
+++ b/src/test/data/JsonUserPrefsStorageTest/ExtraValuesUserPref.json
@@ -9,5 +9,5 @@
       "z" : 99
     }
   },
-  "addressBookFilePath" : "addressbook.json"
+  "addressBookFilePath" : "friendbook.json"
 }

--- a/src/test/data/JsonUserPrefsStorageTest/TypicalUserPref.json
+++ b/src/test/data/JsonUserPrefsStorageTest/TypicalUserPref.json
@@ -7,5 +7,5 @@
       "y" : 100
     }
   },
-  "addressBookFilePath" : "addressbook.json"
+  "addressBookFilePath" : "friendbook.json"
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -176,6 +176,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void updatePlansWithPerson(Person target, Person editedPerson) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Person> getFilteredPersonList() {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/AddPlanCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddPlanCommandTest.java
@@ -209,6 +209,11 @@ public class AddPlanCommandTest {
         }
 
         @Override
+        public void updatePlansWithPerson(Person target, Person editedPerson) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Person> getFilteredPersonList() {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/storage/JsonUserPrefsStorageTest.java
+++ b/src/test/java/seedu/address/storage/JsonUserPrefsStorageTest.java
@@ -73,7 +73,7 @@ public class JsonUserPrefsStorageTest {
     private UserPrefs getTypicalUserPrefs() {
         UserPrefs userPrefs = new UserPrefs();
         userPrefs.setGuiSettings(new GuiSettings(1000, 500, 300, 100));
-        userPrefs.setAddressBookFilePath(Paths.get("addressbook.json"));
+        userPrefs.setAddressBookFilePath(Paths.get("friendbook.json"));
         return userPrefs;
     }
 


### PR DESCRIPTION
Closes #92 
Fixed the following two bugs by updating the implementation of EditCommand (updating Persons in Plans too)
1. add-plan -> edit-friend -> delete-friend causes fxml to remove the plan from UI
2. add-plan -> edit-friend does not reflect in UI

Also, updated the naming of addressbook.json to friendbook.json, and the Friendbook user guide url in the fxml (help command)